### PR TITLE
downgraded activesupport gem under jbuilder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     jbuilder (2.9.1)
-      activesupport (>= 4.2.11.1)
+      activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)


### PR DESCRIPTION
Prod push was failing so trying this fix. 

**Referenced logs from Heroku here:**

Fetching activesupport 4.2.11.1
       Installing activesupport 4.2.11.1
       Using loofah 2.3.1
       Using rails-deprecated_sanitizer 1.0.3
       Using rails-html-sanitizer 1.3.0
       Using globalid 0.4.2
       Using activemodel 4.2.8
       Fetching jbuilder 2.9.1
       Using rails-dom-testing 1.0.9
       Using activejob 4.2.8
       Using activerecord 4.2.8
       Downloading jbuilder-2.9.1 revealed dependencies not in the API or the lockfile
       (activesupport (>= 4.2.0)).
       Either installing with `--full-index` or running `bundle update jbuilder` should
       fix the problem.
 !
 !     Failed to install gems via Bundler.
 !
 !     Push rejected, failed to compile Ruby app.
 !     Push failed