### PR TITLE
downgrade sqlite3 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ gem "activejob", ">= 4.2.11"
 # gem 'capistrano-rails', group: :development
 
 group :development, :test do
-  gem 'sqlite3'
+  gem 'sqlite3', '~> 1.3', '>= 1.3.13'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,7 +144,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.1)
+    sqlite3 (1.3.13)
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -182,7 +182,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
-  sqlite3
+  sqlite3 (~> 1.3, >= 1.3.13)
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)


### PR DESCRIPTION
When launching AWS cloud9 local environment, I was getting "No connection pool for ActiveRecord::Base" and another error referencing sqlite3 version that needs to be compatible with active record. 

I've downgraded from 1.4.1 back to 1.3.13